### PR TITLE
refactor(ldap): canonicalize DirectoryRow imports

### DIFF
--- a/src/sambatui/app_constants.py
+++ b/src/sambatui/app_constants.py
@@ -27,7 +27,7 @@ from .dns.record_types import (
     DNS_RECORD_TYPE_SPECS,
     SUPPORTED_DNS_RECORD_TYPES,
 )
-from .ldap.client import DirectoryRow
+from .ldap.rows import DirectoryRow
 from .core.models import DnsRow
 from .ui.screens import CommandPaletteChoice
 from .smart_view_catalog import SMART_VIEWS

--- a/src/sambatui/controllers/core.py
+++ b/src/sambatui/controllers/core.py
@@ -30,10 +30,10 @@ from ..samba.discovery import (
 )
 from ..dns.parsing import parse_records
 from ..ldap.client import (
-    DirectoryRow,
     LdapDirectoryClient,
     LdapSearchConfig,
 )
+from ..ldap.rows import DirectoryRow
 from ..ldap.sidebar import (
     SidebarItem,
 )

--- a/src/sambatui/controllers/ldap_actions.py
+++ b/src/sambatui/controllers/ldap_actions.py
@@ -9,11 +9,11 @@ from textual import work
 from ..ldap.client import (
     LDAP_ADD_KINDS,
     LDAP_EDITABLE_ATTRIBUTES,
-    DirectoryRow,
     LdapDirectoryClient,
     domain_to_base_dn,
     ldap_dn_in_scope,
 )
+from ..ldap.rows import DirectoryRow
 from ..core.remediation import bounded_int
 from ..ui.screens import (
     FormField,

--- a/src/sambatui/controllers/smart_actions.py
+++ b/src/sambatui/controllers/smart_actions.py
@@ -7,10 +7,8 @@ from textual import work
 from ..dns.names import is_ipv4_reverse_zone
 from ..dns.parsing import parse_records
 from ..dns.validation import validate_record
-from ..ldap.client import (
-    DirectoryRow,
-    LdapDirectoryClient,
-)
+from ..ldap.client import LdapDirectoryClient
+from ..ldap.rows import DirectoryRow
 from ..core.models import DnsRow
 from ..ui.screens import (
     FormField,

--- a/src/sambatui/controllers/views.py
+++ b/src/sambatui/controllers/views.py
@@ -20,9 +20,7 @@ from ..dns.ptr import (
     ptr_target_for_name as dns_ptr_target_for_name,
     reverse_record_for_ipv4 as dns_reverse_record_for_ipv4,
 )
-from ..ldap.client import (
-    DirectoryRow,
-)
+from ..ldap.rows import DirectoryRow
 from ..ldap.sidebar import (
     SidebarItem,
     active_ldap_sidebar_item,

--- a/src/sambatui/ldap/client.py
+++ b/src/sambatui/ldap/client.py
@@ -2,6 +2,10 @@ from __future__ import annotations
 
 from collections.abc import Callable, Mapping
 from contextlib import suppress
+from typing import TYPE_CHECKING
+
+if TYPE_CHECKING:
+    from sambatui.ldap.rows import DirectoryRow
 
 
 def _install_pyasn1_ber_legacy_aliases() -> None:
@@ -67,7 +71,6 @@ from sambatui.ldap.types import (  # noqa: E402
     LDAP_ENCRYPTION_MODES as LDAP_ENCRYPTION_MODES,
     LDAP_SEARCH_KINDS as LDAP_SEARCH_KINDS,
     DirectoryAddKind as DirectoryAddKind,
-    DirectoryRow,
     DirectorySearchKind as DirectorySearchKind,
     LdapAuthMode as LdapAuthMode,
     LdapSearchConfig,

--- a/src/sambatui/ldap/entries.py
+++ b/src/sambatui/ldap/entries.py
@@ -3,7 +3,7 @@ from __future__ import annotations
 from collections.abc import Mapping, Sequence
 
 from sambatui.ldap.filters import KIND_LABELS
-from sambatui.ldap.types import DirectoryRow
+from sambatui.ldap.rows import DirectoryRow
 
 
 def entry_to_directory_row(entry: object, kind: str = "all") -> DirectoryRow:

--- a/src/sambatui/ldap/rows.py
+++ b/src/sambatui/ldap/rows.py
@@ -1,21 +1,13 @@
 from __future__ import annotations
 
-from .client import (
-    DirectoryRow,
-    directory_summary,
-    entry_to_directory_row,
-    first_attr,
-    infer_kind,
-    normalize_attribute_values,
-    normalize_entry_attributes,
-)
+from collections.abc import Mapping, Sequence
+from dataclasses import dataclass
 
-__all__ = [
-    "DirectoryRow",
-    "directory_summary",
-    "entry_to_directory_row",
-    "first_attr",
-    "infer_kind",
-    "normalize_attribute_values",
-    "normalize_entry_attributes",
-]
+
+@dataclass(frozen=True)
+class DirectoryRow:
+    dn: str
+    kind: str
+    name: str
+    summary: str
+    attributes: Mapping[str, Sequence[str]]

--- a/src/sambatui/ldap/types.py
+++ b/src/sambatui/ldap/types.py
@@ -1,6 +1,5 @@
 from __future__ import annotations
 
-from collections.abc import Mapping, Sequence
 from dataclasses import dataclass
 from typing import Literal
 
@@ -73,12 +72,3 @@ class LdapServerSettings:
     host: str
     port: int
     use_ssl: bool
-
-
-@dataclass(frozen=True)
-class DirectoryRow:
-    dn: str
-    kind: str
-    name: str
-    summary: str
-    attributes: Mapping[str, Sequence[str]]

--- a/src/sambatui/smart_views/ldap.py
+++ b/src/sambatui/smart_views/ldap.py
@@ -3,7 +3,8 @@ from __future__ import annotations
 from collections.abc import Sequence
 from datetime import UTC, datetime, timedelta
 
-from ..ldap.client import DirectoryRow, first_attr
+from ..ldap.client import first_attr
+from ..ldap.rows import DirectoryRow
 from .models import SmartViewRow
 
 

--- a/src/sambatui/ui/details.py
+++ b/src/sambatui/ui/details.py
@@ -2,7 +2,7 @@ from __future__ import annotations
 
 from collections.abc import Callable, Iterable, Sequence
 
-from sambatui.ldap.client import DirectoryRow
+from sambatui.ldap.rows import DirectoryRow
 from sambatui.core.models import DnsRow
 from sambatui.smart_views import SmartViewRow
 

--- a/src/sambatui/ui/tables.py
+++ b/src/sambatui/ui/tables.py
@@ -3,7 +3,7 @@ from __future__ import annotations
 from collections.abc import Iterable
 from typing import TypeAlias
 
-from sambatui.ldap.client import DirectoryRow
+from sambatui.ldap.rows import DirectoryRow
 from sambatui.core.models import DnsRow
 from sambatui.smart_views import SmartViewRow
 

--- a/tests/sambatui/ldap/test_sidebar.py
+++ b/tests/sambatui/ldap/test_sidebar.py
@@ -1,7 +1,7 @@
 from hypothesis import given
 from hypothesis import strategies as st
 
-from sambatui.ldap.client import DirectoryRow
+from sambatui.ldap.rows import DirectoryRow
 from sambatui.ldap.sidebar import (
     SidebarItem,
     active_ldap_sidebar_item,

--- a/tests/sambatui/ldap/test_sidebar_edges.py
+++ b/tests/sambatui/ldap/test_sidebar_edges.py
@@ -1,6 +1,6 @@
 from __future__ import annotations
 
-from sambatui.ldap.client import DirectoryRow
+from sambatui.ldap.rows import DirectoryRow
 from sambatui.ldap.sidebar import ldap_structure_nodes
 from sambatui.core.settings import ConnectionSettings
 

--- a/tests/sambatui/smart_views/test_smart_views.py
+++ b/tests/sambatui/smart_views/test_smart_views.py
@@ -5,7 +5,7 @@ from datetime import UTC, datetime, timedelta
 from hypothesis import given
 from hypothesis import strategies as st
 
-from sambatui.ldap.client import DirectoryRow
+from sambatui.ldap.rows import DirectoryRow
 from sambatui.core.models import DnsRow
 from sambatui.smart_views import (
     ACCOUNTDISABLE,

--- a/tests/sambatui/smart_views/test_smart_views_edges.py
+++ b/tests/sambatui/smart_views/test_smart_views_edges.py
@@ -7,7 +7,7 @@ from hypothesis import given
 from hypothesis import strategies as st
 
 from sambatui import smart_views as smart_module
-from sambatui.ldap.client import DirectoryRow
+from sambatui.ldap.rows import DirectoryRow
 from sambatui.core.models import DnsRow
 from sambatui.smart_views import (
     ACCOUNTDISABLE,

--- a/tests/sambatui/test_app_ldap_actions.py
+++ b/tests/sambatui/test_app_ldap_actions.py
@@ -9,7 +9,8 @@ from sambatui.app import (
 )
 from textual.widgets import DataTable, Input
 
-from sambatui.ldap.client import DirectoryRow, LdapDirectoryClient
+from sambatui.ldap.client import LdapDirectoryClient
+from sambatui.ldap.rows import DirectoryRow
 from sambatui.ui.screens import (
     FormField,
     FormValidator,

--- a/tests/sambatui/test_app_navigation.py
+++ b/tests/sambatui/test_app_navigation.py
@@ -11,7 +11,7 @@ from sambatui.app import (
 )
 from textual.widgets import Button, DataTable, Input
 
-from sambatui.ldap.client import DirectoryRow
+from sambatui.ldap.rows import DirectoryRow
 from sambatui.smart_views import SmartViewRow
 from sambatui.ui.screens import (
     CommandPaletteScreen,

--- a/tests/sambatui/test_app_rendering.py
+++ b/tests/sambatui/test_app_rendering.py
@@ -9,7 +9,8 @@ from sambatui.app import (
 )
 from textual.widgets import DataTable, Input, Static
 
-from sambatui.ldap.client import DirectoryRow, LdapDirectoryClient
+from sambatui.ldap.client import LdapDirectoryClient
+from sambatui.ldap.rows import DirectoryRow
 from sambatui.smart_view_catalog import SmartViewOptions
 from sambatui.smart_views import SmartViewRow
 

--- a/tests/sambatui/test_controller_edges.py
+++ b/tests/sambatui/test_controller_edges.py
@@ -18,7 +18,8 @@ from sambatui.controllers.helpers import (
     setup_auth_values,
     sort_direction,
 )
-from sambatui.ldap.client import DirectoryRow, LdapDirectoryClient
+from sambatui.ldap.client import LdapDirectoryClient
+from sambatui.ldap.rows import DirectoryRow
 from sambatui.ldap.sidebar import SidebarItem
 from sambatui.samba.discovery import DiscoveredService
 from sambatui.smart_view_catalog import (

--- a/tests/sambatui/test_integration_behaviors.py
+++ b/tests/sambatui/test_integration_behaviors.py
@@ -23,7 +23,6 @@ from sambatui.dns.parsing import parse_records, parse_zones
 from sambatui.dns.ptr import ptr_target_for_name, reverse_record_for_ipv4
 from sambatui.dns.validation import valid_dns_name, validate_record
 from sambatui.ldap.client import (
-    DirectoryRow,
     LdapDirectoryClient,
     LdapSearchConfig,
     build_directory_filter,
@@ -38,6 +37,7 @@ from sambatui.ldap.client import (
     normalize_entry_attributes,
     parse_ldap_server,
 )
+from sambatui.ldap.rows import DirectoryRow
 from sambatui.core.remediation import actionable_error, bounded_int
 from sambatui.core.settings import ConnectionSettings
 from sambatui.smart_views import (


### PR DESCRIPTION
Closes #68\n\n## Summary\n- Move DirectoryRow to sambatui.ldap.rows as canonical import path\n- Remove DirectoryRow from ldap.types and avoid client runtime re-export\n- Update app and tests to import DirectoryRow from rows\n\n## Validation\n- mise run check