### PR TITLE
refactor(smart-views): centralize finding metadata defaults

### DIFF
--- a/src/sambatui/app_constants.py
+++ b/src/sambatui/app_constants.py
@@ -30,13 +30,20 @@ from .dns.record_types import (
 from .ldap.rows import DirectoryRow
 from .core.models import DnsRow
 from .ui.screens import CommandPaletteChoice
-from .smart_view_catalog import SMART_VIEWS, smart_view_shortcut_range
+from .smart_view_catalog import (
+    SMART_VIEWS,
+    SmartViewSource,
+    all_smart_view_shortcut_range,
+    smart_view_shortcut_range,
+)
 
-DNS_FINDING_SHORTCUTS = smart_view_shortcut_range("DNS")
-LDAP_FINDING_SHORTCUTS = smart_view_shortcut_range("LDAP")
+DNS_FINDING_SHORTCUTS = smart_view_shortcut_range(SmartViewSource.DNS)
+LDAP_FINDING_SHORTCUTS = smart_view_shortcut_range(SmartViewSource.LDAP)
+ALL_FINDING_SHORTCUTS = all_smart_view_shortcut_range()
+DASHBOARD_FINDING_SHORTCUT = smart_view_shortcut_range(SmartViewSource.FULL)
 KEY_HINTS = {
-    "dns_tab": f"DNS: ? help  Ctrl+P palette  w setup  Ctrl+O connection  z zones  c discover  S picker  {DNS_FINDING_SHORTCUTS} findings  q query  a add  u update  d delete  / search",
-    "ldap_tab": f"LDAP: ? help  Ctrl+P palette  w setup  Ctrl+O connection  c discover  L search  {LDAP_FINDING_SHORTCUTS} findings  a add  u edit one  d delete selected  Space select  m load more  S picker  / search  r refresh",
+    "dns_tab": f"DNS: ? help  Ctrl+P palette  w setup  Ctrl+O connection  z zones  c discover  S picker  {DNS_FINDING_SHORTCUTS} DNS findings  {DASHBOARD_FINDING_SHORTCUT} dashboard  q query  a add  u update  d delete  / search",
+    "ldap_tab": f"LDAP: ? help  Ctrl+P palette  w setup  Ctrl+O connection  c discover  L search  {LDAP_FINDING_SHORTCUTS} LDAP findings  {DASHBOARD_FINDING_SHORTCUT} dashboard  a add  u edit one  d delete selected  Space select  m load more  S picker  / search  r refresh",
 }
 SIDE_TAB_IDS = ("dns_tab", "ldap_tab")
 CONNECTION_STATE_INPUTS = (

--- a/src/sambatui/controllers/ldap_actions.py
+++ b/src/sambatui/controllers/ldap_actions.py
@@ -18,6 +18,7 @@ from ..core.remediation import bounded_int
 from ..ui.screens import (
     FormField,
 )
+from ..smart_view_catalog import SMART_ROW_LIMIT_DEFAULT
 from ..app_constants import (
     DEFAULT_LDAP_COMPATIBILITY,
     DEFAULT_LDAP_ENCRYPTION,
@@ -62,7 +63,7 @@ class AppLdapActionsMixin(AppControllerBase):
         return (
             "Max rows",
             "max_rows",
-            "500",
+            str(SMART_ROW_LIMIT_DEFAULT),
             self.val("smart_max_rows") or DEFAULT_SMART_MAX_ROWS,
         )
 

--- a/src/sambatui/controllers/smart_actions.py
+++ b/src/sambatui/controllers/smart_actions.py
@@ -24,8 +24,10 @@ from ..smart_view_catalog import (
     SMART_VIEWS,
     SMART_ROW_LIMIT_MAX,
     SMART_ROW_LIMIT_STEP,
+    SMART_VIEW_DEFAULTS,
     SmartViewDefinition,
     SmartViewOptions,
+    SmartViewSource,
 )
 from ..smart_views import (
     SmartViewCheckResult,
@@ -59,7 +61,13 @@ LDAP_USERS_WITHOUT_GROUPS_VIEW_ID = "ldap_users_without_groups"
 class AppSmartActionsMixin(AppControllerBase):
     def smart_view_choices(self) -> list[SmartViewChoice]:
         return [
-            (view.shortcut, view.view_id, view.source, view.label, view.description)
+            (
+                view.shortcut,
+                view.view_id,
+                view.source_label,
+                view.label,
+                view.description,
+            )
             for view in SMART_VIEWS
         ]
 
@@ -70,7 +78,7 @@ class AppSmartActionsMixin(AppControllerBase):
                 (
                     "Stale/inactive days",
                     "days",
-                    "90",
+                    str(SMART_VIEW_DEFAULTS.days),
                     self.val("smart_days") or DEFAULT_SMART_DAYS,
                 ),
             ),
@@ -79,7 +87,7 @@ class AppSmartActionsMixin(AppControllerBase):
                 (
                     "Disabled cleanup days",
                     "disabled_days",
-                    "180",
+                    str(SMART_VIEW_DEFAULTS.disabled_days),
                     self.val("smart_disabled_days") or DEFAULT_SMART_DISABLED_DAYS,
                 ),
             ),
@@ -88,7 +96,7 @@ class AppSmartActionsMixin(AppControllerBase):
                 (
                     "Never-logged-in days",
                     "never_logged_days",
-                    "30",
+                    str(SMART_VIEW_DEFAULTS.never_logged_days),
                     self.val("smart_never_logged_days")
                     or DEFAULT_SMART_NEVER_LOGGED_DAYS,
                 ),
@@ -210,7 +218,7 @@ class AppSmartActionsMixin(AppControllerBase):
                 values, SmartViewOptions.from_values(values), refreshed=True
             )
             return
-        if view.source != "DNS" and not values:
+        if view.source is not SmartViewSource.DNS and not values:
             self.refresh_smart_view()
             return
 
@@ -330,7 +338,7 @@ class AppSmartActionsMixin(AppControllerBase):
         values: dict[str, str],
         options: SmartViewOptions,
     ) -> list[SmartViewRow] | None:
-        if view.source == "DNS":
+        if view.source is SmartViewSource.DNS:
             records_by_zone = await self.dns_records_for_smart_view()
             if records_by_zone is None:
                 return None

--- a/src/sambatui/controllers/views.py
+++ b/src/sambatui/controllers/views.py
@@ -27,7 +27,6 @@ from ..ldap.sidebar import (
     ldap_sidebar_items,
 )
 from ..core.models import DnsRow
-from ..core.remediation import bounded_int
 from ..smart_views import (
     SmartViewRow,
     directory_object_name,
@@ -40,7 +39,9 @@ from ..smart_view_catalog import (
     FULL_HEALTH_VIEW_ID,
     SMART_DEFAULT_SORTS,
     SMART_VIEW_BY_ID,
-    SMART_VIEWS,
+    SmartViewOptions,
+    SmartViewSource,
+    smart_views_for_source,
 )
 from ..ui.details import (
     details_empty_text,
@@ -165,7 +166,7 @@ class AppViewsMixin(AppControllerBase):
         self.select_smart_view_cursor()
 
     def populate_finding_sidebar(self, table_id: str, source: str) -> None:
-        views = [view for view in SMART_VIEWS if view.source == source]
+        views = list(smart_views_for_source(source))
         items = [
             SidebarItem(
                 view.label.removeprefix(f"{source} "), view.view_id, "smart_view"
@@ -227,8 +228,9 @@ class AppViewsMixin(AppControllerBase):
         view = SMART_VIEW_BY_ID.get(self.current_smart_view_id)
         if view is None or view.view_id == FULL_HEALTH_VIEW_ID:
             return ""
-        label = view.label.removeprefix(f"{view.source} ")
-        return f"— {view.source} / Findings / {label} (Esc clears)"
+        source = view.source_label
+        label = view.label.removeprefix(f"{source} ")
+        return f"— {source} / Findings / {label} (Esc clears)"
 
     def update_records_title(self) -> None:
         self.query_one("#records_title", Label).update(self.records_title())
@@ -339,12 +341,9 @@ class AppViewsMixin(AppControllerBase):
     def populate_smart_view(self, title: str, rows: list[SmartViewRow]) -> None:
         self.view_mode = "smart"
         view = SMART_VIEW_BY_ID.get(self.current_smart_view_id)
-        context = (
-            view.source
-            if view is not None and view.source in {"DNS", "LDAP"}
-            else "Findings"
-        )
-        tab_id = "ldap_tab" if context == "LDAP" else "dns_tab"
+        source = view.source.sidebar_source if view is not None else None
+        context = source.value if source is not None else "Findings"
+        tab_id = "ldap_tab" if source is SmartViewSource.LDAP else "dns_tab"
         with suppress(Exception):
             self.query_one("#side_tabs", TabbedContent).active = tab_id
             self.refresh_key_hints()
@@ -429,10 +428,14 @@ class AppViewsMixin(AppControllerBase):
             self.select_record_range(start, end)
 
     def smart_options_for_passive_findings(self) -> tuple[int, int, int]:
-        days = bounded_int(self.val("smart_days"), 90)
-        disabled_days = bounded_int(self.val("smart_disabled_days"), 180)
-        never_logged_days = bounded_int(self.val("smart_never_logged_days"), 30)
-        return days, disabled_days, never_logged_days
+        options = SmartViewOptions.from_values(
+            {
+                "smart_days": self.val("smart_days"),
+                "smart_disabled_days": self.val("smart_disabled_days"),
+                "smart_never_logged_days": self.val("smart_never_logged_days"),
+            }
+        )
+        return options.days, options.disabled_days, options.never_logged_days
 
     def passive_dns_findings(self, rows: Sequence[DnsRow]) -> list[SmartViewRow]:
         zone = self.val("zone")
@@ -671,7 +674,7 @@ class AppViewsMixin(AppControllerBase):
         self.smart_view_rows = []
         self.current_smart_sort_field = ""
         self.current_smart_sort_reverse = False
-        if view is not None and view.source == "LDAP":
+        if view is not None and view.source is SmartViewSource.LDAP:
             self.view_mode = "directory"
             self.set_records_columns(DIRECTORY_COLUMNS)
             self.query_one("#records_title", Label).update(self.directory_title())

--- a/src/sambatui/core/settings.py
+++ b/src/sambatui/core/settings.py
@@ -19,6 +19,10 @@ from .config import (
     DEFAULT_PASSWORD,
     DEFAULT_PASSWORD_FILE,
     DEFAULT_SERVER,
+    DEFAULT_SMART_DAYS,
+    DEFAULT_SMART_DISABLED_DAYS,
+    DEFAULT_SMART_MAX_ROWS,
+    DEFAULT_SMART_NEVER_LOGGED_DAYS,
     DEFAULT_USER,
     DEFAULT_ZONE,
 )
@@ -93,6 +97,10 @@ class ConnectionSettings:
     ldap_encryption: str = DEFAULT_LDAP_ENCRYPTION
     ldap_compatibility: str = DEFAULT_LDAP_COMPATIBILITY
     auto_ptr: str = DEFAULT_AUTO_PTR
+    smart_days: str = DEFAULT_SMART_DAYS
+    smart_disabled_days: str = DEFAULT_SMART_DISABLED_DAYS
+    smart_never_logged_days: str = DEFAULT_SMART_NEVER_LOGGED_DAYS
+    smart_max_rows: str = DEFAULT_SMART_MAX_ROWS
     password_file: str = str(DEFAULT_PASSWORD_FILE)
 
     @classmethod
@@ -125,6 +133,14 @@ class ConnectionSettings:
                 "ldap_compatibility", DEFAULT_LDAP_COMPATIBILITY
             ),
             auto_ptr=value_or_default("auto_ptr", DEFAULT_AUTO_PTR),
+            smart_days=value_or_default("smart_days", DEFAULT_SMART_DAYS),
+            smart_disabled_days=value_or_default(
+                "smart_disabled_days", DEFAULT_SMART_DISABLED_DAYS
+            ),
+            smart_never_logged_days=value_or_default(
+                "smart_never_logged_days", DEFAULT_SMART_NEVER_LOGGED_DAYS
+            ),
+            smart_max_rows=value_or_default("smart_max_rows", DEFAULT_SMART_MAX_ROWS),
             password_file=value_or_default("password_file", str(DEFAULT_PASSWORD_FILE)),
         )
 
@@ -218,9 +234,38 @@ class ConnectionSettings:
             ),
         ]
 
+    def smart_form_fields(self) -> list[FormField]:
+        return [
+            (
+                "Finding inactive/stale days — used by passive and LDAP findings.",
+                "smart_days",
+                DEFAULT_SMART_DAYS,
+                self.smart_days or DEFAULT_SMART_DAYS,
+            ),
+            (
+                "Finding disabled cleanup days — delete-candidate threshold.",
+                "smart_disabled_days",
+                DEFAULT_SMART_DISABLED_DAYS,
+                self.smart_disabled_days or DEFAULT_SMART_DISABLED_DAYS,
+            ),
+            (
+                "Finding never-logged-in days — delete-candidate threshold.",
+                "smart_never_logged_days",
+                DEFAULT_SMART_NEVER_LOGGED_DAYS,
+                self.smart_never_logged_days or DEFAULT_SMART_NEVER_LOGGED_DAYS,
+            ),
+            (
+                "Finding max rows — default smart-view directory/result limit.",
+                "smart_max_rows",
+                DEFAULT_SMART_MAX_ROWS,
+                self.smart_max_rows or DEFAULT_SMART_MAX_ROWS,
+            ),
+        ]
+
     def form_fields(self) -> list[FormField]:
         return [
             *self.samba_form_fields(),
             *self.ldap_form_fields(),
+            *self.smart_form_fields(),
             *self.convenience_form_fields(),
         ]

--- a/src/sambatui/smart_view_catalog.py
+++ b/src/sambatui/smart_view_catalog.py
@@ -1,7 +1,15 @@
 from __future__ import annotations
 
+from collections.abc import Mapping
 from dataclasses import dataclass
+from enum import StrEnum
 
+from .core.config import (
+    DEFAULT_SMART_DAYS,
+    DEFAULT_SMART_DISABLED_DAYS,
+    DEFAULT_SMART_MAX_ROWS,
+    DEFAULT_SMART_NEVER_LOGGED_DAYS,
+)
 from .core.remediation import bounded_int
 
 
@@ -17,16 +25,62 @@ FULL_HEALTH_LDAP_VIEW_IDS = (
     "ldap_users_without_groups",
     "ldap_delete_candidates",
 )
-SMART_ROW_LIMIT_DEFAULT = 500
+SMART_DAYS_FALLBACK = 90
+SMART_DISABLED_DAYS_FALLBACK = 180
+SMART_NEVER_LOGGED_DAYS_FALLBACK = 30
+SMART_ROW_LIMIT_FALLBACK = 500
 SMART_ROW_LIMIT_STEP = 200
 SMART_ROW_LIMIT_MAX = 5000
+
+
+class SmartViewSource(StrEnum):
+    DNS = "DNS"
+    LDAP = "LDAP"
+    FULL = "Full"
+
+    @property
+    def row_source(self) -> str:
+        return "dashboard" if self is SmartViewSource.FULL else self.value.lower()
+
+    @property
+    def sidebar_source(self) -> "SmartViewSource | None":
+        return self if self in {SmartViewSource.DNS, SmartViewSource.LDAP} else None
+
+
+@dataclass(frozen=True)
+class SmartViewDefaults:
+    days: int
+    disabled_days: int
+    never_logged_days: int
+    max_rows: int
+
+    @classmethod
+    def configured(cls) -> "SmartViewDefaults":
+        return cls(
+            days=bounded_int(DEFAULT_SMART_DAYS, SMART_DAYS_FALLBACK),
+            disabled_days=bounded_int(
+                DEFAULT_SMART_DISABLED_DAYS, SMART_DISABLED_DAYS_FALLBACK
+            ),
+            never_logged_days=bounded_int(
+                DEFAULT_SMART_NEVER_LOGGED_DAYS, SMART_NEVER_LOGGED_DAYS_FALLBACK
+            ),
+            max_rows=bounded_int(
+                DEFAULT_SMART_MAX_ROWS,
+                SMART_ROW_LIMIT_FALLBACK,
+                maximum=SMART_ROW_LIMIT_MAX,
+            ),
+        )
+
+
+SMART_VIEW_DEFAULTS = SmartViewDefaults.configured()
+SMART_ROW_LIMIT_DEFAULT = SMART_VIEW_DEFAULTS.max_rows
 
 
 @dataclass(frozen=True)
 class SmartViewDefinition:
     view_id: str
     shortcut: str
-    source: str
+    source: SmartViewSource
     label: str
     description: str
     needs_days: bool = False
@@ -39,7 +93,15 @@ class SmartViewDefinition:
 
     @property
     def needs_ldap(self) -> bool:
-        return self.source == "LDAP" or self.needs_ldap_connection
+        return self.source is SmartViewSource.LDAP or self.needs_ldap_connection
+
+    @property
+    def source_label(self) -> str:
+        return self.source.value
+
+    @property
+    def row_source(self) -> str:
+        return self.source.row_source
 
 
 @dataclass(frozen=True)
@@ -50,14 +112,27 @@ class SmartViewOptions:
     max_rows: int
 
     @classmethod
-    def from_values(cls, values: dict[str, str]) -> SmartViewOptions:
+    def from_values(
+        cls,
+        values: Mapping[str, str],
+        defaults: SmartViewDefaults = SMART_VIEW_DEFAULTS,
+    ) -> "SmartViewOptions":
         return cls(
-            days=bounded_int(values.get("days"), 90),
-            disabled_days=bounded_int(values.get("disabled_days"), 180),
-            never_logged_days=bounded_int(values.get("never_logged_days"), 30),
+            days=bounded_int(
+                values.get("days") or values.get("smart_days"), defaults.days
+            ),
+            disabled_days=bounded_int(
+                values.get("disabled_days") or values.get("smart_disabled_days"),
+                defaults.disabled_days,
+            ),
+            never_logged_days=bounded_int(
+                values.get("never_logged_days")
+                or values.get("smart_never_logged_days"),
+                defaults.never_logged_days,
+            ),
             max_rows=bounded_int(
-                values.get("max_rows"),
-                SMART_ROW_LIMIT_DEFAULT,
+                values.get("max_rows") or values.get("smart_max_rows"),
+                defaults.max_rows,
                 maximum=SMART_ROW_LIMIT_MAX,
             ),
         )
@@ -67,7 +142,7 @@ SMART_VIEWS = (
     SmartViewDefinition(
         FULL_HEALTH_VIEW_ID,
         "8",
-        "Full",
+        SmartViewSource.FULL,
         "Full health dashboard",
         "Run key DNS and LDAP hygiene checks together with grouped summary counts.",
         needs_days=True,
@@ -79,28 +154,28 @@ SMART_VIEWS = (
     SmartViewDefinition(
         "dns_duplicates",
         "1",
-        "DNS",
+        SmartViewSource.DNS,
         "DNS duplicates/conflicts",
         "Identical DNS records and CNAME names that also have other record types.",
     ),
     SmartViewDefinition(
         "dns_a_without_ptr",
         "2",
-        "DNS",
+        SmartViewSource.DNS,
         "DNS A records without matching PTR",
         "Forward IPv4 A records missing reverse DNS, or pointing at the wrong PTR.",
     ),
     SmartViewDefinition(
         "dns_ptr_without_a",
         "3",
-        "DNS",
+        SmartViewSource.DNS,
         "DNS PTR records without matching A",
         "Reverse PTR records with no forward A record, or mismatched forward IPs.",
     ),
     SmartViewDefinition(
         "ldap_inactive_users",
         "4",
-        "LDAP",
+        SmartViewSource.LDAP,
         "LDAP inactive enabled users",
         "Enabled users whose last logon is older than the inactivity threshold.",
         needs_days=True,
@@ -110,7 +185,7 @@ SMART_VIEWS = (
     SmartViewDefinition(
         "ldap_delete_candidates",
         "5",
-        "LDAP",
+        SmartViewSource.LDAP,
         "LDAP user cleanup candidates",
         "Disabled users past retention, plus enabled users that never logged in.",
         needs_disabled_days=True,
@@ -121,7 +196,7 @@ SMART_VIEWS = (
     SmartViewDefinition(
         "ldap_stale_computers",
         "6",
-        "LDAP",
+        SmartViewSource.LDAP,
         "LDAP stale computer accounts",
         "Computer accounts with old or missing last-logon data.",
         needs_days=True,
@@ -132,7 +207,7 @@ SMART_VIEWS = (
     SmartViewDefinition(
         "ldap_users_without_groups",
         "7",
-        "LDAP",
+        SmartViewSource.LDAP,
         "LDAP users with no secondary groups",
         "Enabled users whose memberOf list is empty except for their primary group.",
         default_sort_field="object",
@@ -149,12 +224,31 @@ SMART_DEFAULT_SORTS = {
 }
 
 
-def smart_views_for_source(source: str) -> tuple[SmartViewDefinition, ...]:
-    return tuple(view for view in SMART_VIEWS if view.source == source)
+def smart_view_source(value: str | SmartViewSource) -> SmartViewSource | None:
+    try:
+        return value if isinstance(value, SmartViewSource) else SmartViewSource(value)
+    except ValueError:
+        return None
 
 
-def smart_view_shortcut_range(source: str) -> str:
-    shortcuts = [view.shortcut for view in smart_views_for_source(source)]
+def smart_views_for_source(
+    source: str | SmartViewSource,
+) -> tuple[SmartViewDefinition, ...]:
+    parsed_source = smart_view_source(source)
+    return tuple(view for view in SMART_VIEWS if view.source is parsed_source)
+
+
+def shortcut_range(shortcuts: list[str]) -> str:
     if not shortcuts:
         return ""
     return shortcuts[0] if len(shortcuts) == 1 else f"{shortcuts[0]}-{shortcuts[-1]}"
+
+
+def smart_view_shortcut_range(source: str | SmartViewSource) -> str:
+    return shortcut_range([view.shortcut for view in smart_views_for_source(source)])
+
+
+def all_smart_view_shortcut_range() -> str:
+    return shortcut_range(
+        [view.shortcut for view in sorted(SMART_VIEWS, key=lambda view: view.shortcut)]
+    )

--- a/src/sambatui/ui/screens/help.py
+++ b/src/sambatui/ui/screens/help.py
@@ -5,6 +5,11 @@ from textual.events import Key
 from textual.containers import Horizontal, Vertical
 from textual.widgets import Button, Static
 
+from sambatui.smart_view_catalog import (
+    all_smart_view_shortcut_range,
+    smart_view_shortcut_range,
+)
+
 from .base import FocusedModalScreen
 
 
@@ -26,7 +31,9 @@ class HelpScreen(FocusedModalScreen[None]):
     #help_buttons Button { width: 14; margin-left: 1; }
     """
 
-    HELP_TEXT = """Connection
+    FINDING_SHORTCUTS = all_smart_view_shortcut_range()
+    DASHBOARD_SHORTCUT = smart_view_shortcut_range("Full")
+    HELP_TEXT = f"""Connection
   Ctrl+P    Open searchable command palette
   w         Run first-run setup wizard
   Ctrl+O    Open/edit connection settings (also via command palette)
@@ -39,7 +46,7 @@ Main tabs
   L         Search LDAP from anywhere
   m         Load 200 more rows for the last LDAP search
   S         Pick a DNS/LDAP finding filter from a list
-  1-8       Open finding filters directly; 8 runs full health dashboard
+  {FINDING_SHORTCUTS}       Open finding filters directly; {DASHBOARD_SHORTCUT} runs full health dashboard
   z         Load DNS zones
 
 Navigation

--- a/src/sambatui/ui/screens/smart_picker.py
+++ b/src/sambatui/ui/screens/smart_picker.py
@@ -7,6 +7,8 @@ from textual.events import Key
 from textual.containers import Horizontal, Vertical
 from textual.widgets import Button, DataTable, Static
 
+from sambatui.smart_view_catalog import all_smart_view_shortcut_range
+
 from .base import FocusedModalScreen
 
 
@@ -39,7 +41,7 @@ class SmartViewPickerScreen(FocusedModalScreen[str | None]):
         with Vertical(id="smart_view_dialog"):
             yield Static("Smart views", id="smart_view_title")
             yield Static(
-                "Pick a read-only hygiene view. Keys 1-8 run views directly; Enter selects.",
+                f"Pick a read-only hygiene view. Keys {all_smart_view_shortcut_range()} run views directly; Enter selects.",
                 id="smart_view_hint",
             )
             table = DataTable(id="smart_view_table", cursor_type="row")

--- a/src/sambatui/ui/tables.py
+++ b/src/sambatui/ui/tables.py
@@ -5,6 +5,7 @@ from typing import TypeAlias
 
 from sambatui.ldap.rows import DirectoryRow
 from sambatui.core.models import DnsRow
+from sambatui.smart_view_catalog import all_smart_view_shortcut_range
 from sambatui.smart_views import SmartViewRow
 
 DNS_COLUMNS = ("✓", "Name", "Type", "Value", "TTL", "Records", "Children")
@@ -31,7 +32,7 @@ LDAP_EMPTY_STATE = (
 )
 SMART_EMPTY_STATE = (
     "No findings shown",
-    "Press S to pick a DNS/LDAP finding or 1-7 for shortcuts; / filters findings.",
+    f"Press S to pick a DNS/LDAP finding or {all_smart_view_shortcut_range()} for shortcuts; / filters findings.",
 )
 
 

--- a/tests/sambatui/smart_views/test_smart_views.py
+++ b/tests/sambatui/smart_views/test_smart_views.py
@@ -13,6 +13,8 @@ from sambatui.smart_view_catalog import (
     SMART_ROW_LIMIT_DEFAULT,
     SMART_ROW_LIMIT_MAX,
     SmartViewOptions,
+    SmartViewSource,
+    all_smart_view_shortcut_range,
     smart_view_shortcut_range,
     smart_views_for_source,
 )
@@ -79,8 +81,13 @@ def filetime_for(value: datetime) -> str:
 def test_smart_view_catalog_centralizes_shortcuts_defaults_and_row_limits() -> None:
     assert smart_view_shortcut_range("DNS") == "1-3"
     assert smart_view_shortcut_range("LDAP") == "4-7"
+    assert smart_view_shortcut_range(SmartViewSource.FULL) == "8"
+    assert all_smart_view_shortcut_range() == "1-8"
     assert smart_view_shortcut_range("missing") == ""
-    assert [view.source for view in smart_views_for_source("DNS")] == ["DNS"] * 3
+    assert [view.source_label for view in smart_views_for_source("DNS")] == ["DNS"] * 3
+    assert SmartViewSource.DNS.row_source == "dns"
+    assert SmartViewSource.FULL.row_source == "dashboard"
+    assert smart_views_for_source("Full")[0].row_source == "dashboard"
     assert SMART_DEFAULT_SORTS["ldap_inactive_users"] == ("age", True)
     assert SMART_DEFAULT_SORTS["ldap_users_without_groups"] == ("object", False)
 
@@ -88,6 +95,15 @@ def test_smart_view_catalog_centralizes_shortcuts_defaults_and_row_limits() -> N
 
     assert options.max_rows == SMART_ROW_LIMIT_MAX
     assert SmartViewOptions.from_values({}).max_rows == SMART_ROW_LIMIT_DEFAULT
+    configured = SmartViewOptions.from_values(
+        {
+            "smart_days": "123",
+            "smart_disabled_days": "234",
+            "smart_never_logged_days": "45",
+            "smart_max_rows": "321",
+        }
+    )
+    assert configured == SmartViewOptions(123, 234, 45, 321)
 
 
 def test_full_health_dashboard_rows_show_summary_failures_then_details() -> None:

--- a/tests/sambatui/test_integration_behaviors.py
+++ b/tests/sambatui/test_integration_behaviors.py
@@ -488,6 +488,8 @@ def test_settings_branches_and_config_conversion(tmp_path: Path) -> None:
     assert settings.ldap_config("DC=override").base_dn == "DC=override"
     fields = settings.form_fields()
     assert fields[0][1] == "server"
+    assert "smart_days" in [field[1] for field in fields]
+    assert "smart_max_rows" in [field[1] for field in fields]
     assert fields[-1][1] == "password_file"
 
 


### PR DESCRIPTION
## Summary
- centralize smart-view defaults/row limits and support smart default fields in connection settings
- derive finding shortcut ranges/help/picker/empty state/key hints from smart-view metadata
- normalize smart-view source metadata with typed source values

Closes #63
Closes #64

## Validation
- mise run check