### PR TITLE
fix: harden secret handling

### DIFF
--- a/src/sambatui/controllers/core.py
+++ b/src/sambatui/controllers/core.py
@@ -5,6 +5,7 @@ import os
 import shutil
 import socket
 from collections.abc import AsyncIterator
+from dataclasses import replace
 from contextlib import asynccontextmanager, suppress
 from pathlib import Path
 
@@ -78,9 +79,11 @@ class AppCoreMixin(AppControllerBase):
         self.initialize_state()
         self.initialize_view()
 
-        if not shutil.which("samba-tool"):
+        samba_tool = shutil.which("samba-tool")
+        if not samba_tool:
             self.report_error("samba-tool not found in PATH")
             return
+        self.samba_tool_executable = samba_tool
 
         self.set_initial_connection_status()
         if self.connection_needs_setup():
@@ -244,7 +247,9 @@ class AppCoreMixin(AppControllerBase):
         return self.connection_settings().path_password_file
 
     def samba_config(self) -> SambaToolConfig:
-        return self.connection_settings().samba_config()
+        config = self.connection_settings().samba_config()
+        executable = getattr(self, "samba_tool_executable", "samba-tool")
+        return replace(config, executable=executable)
 
     def samba_client(self) -> SambaToolClient:
         return SambaToolClient(self.samba_config())
@@ -351,10 +356,12 @@ class AppCoreMixin(AppControllerBase):
             return 2, error
 
         self.set_status(f"Running: {client.status_command(cmd)}")
+        env = client.execution_env() if hasattr(client, "execution_env") else None
         proc = await asyncio.create_subprocess_exec(
             *cmd,
             stdout=asyncio.subprocess.PIPE,
             stderr=asyncio.subprocess.STDOUT,
+            env=env,
         )
         out_bytes, _ = await proc.communicate()
         output = out_bytes.decode(errors="replace")

--- a/src/sambatui/controllers/ldap_actions.py
+++ b/src/sambatui/controllers/ldap_actions.py
@@ -52,7 +52,7 @@ class AppLdapActionsMixin(AppControllerBase):
                 self.val("ldap_encryption") or DEFAULT_LDAP_ENCRYPTION,
             ),
             (
-                "LDAP compatibility — only if DC needs relaxed TLS/schema; with password auth prefer UPN user",
+                "LDAP compatibility — WARNING: disables TLS certificate verification; use only for trusted legacy DCs",
                 "ldap_compatibility",
                 "on | off",
                 self.val("ldap_compatibility") or DEFAULT_LDAP_COMPATIBILITY,

--- a/src/sambatui/controllers/setup.py
+++ b/src/sambatui/controllers/setup.py
@@ -75,7 +75,7 @@ class AppSetupMixin(AppControllerBase):
                 self.val("ldap_encryption") or DEFAULT_LDAP_ENCRYPTION,
             ),
             (
-                "LDAP compatibility — only if DC needs relaxed TLS/schema; with password auth prefer UPN user.",
+                "LDAP compatibility — WARNING: disables TLS certificate verification; use only for trusted legacy DCs.",
                 "ldap_compatibility",
                 "on | off",
                 self.val("ldap_compatibility") or DEFAULT_LDAP_COMPATIBILITY,

--- a/src/sambatui/core/config.py
+++ b/src/sambatui/core/config.py
@@ -1,7 +1,9 @@
 from __future__ import annotations
 
 import os
+import stat
 import subprocess
+import tempfile
 import tomllib
 from collections.abc import Callable, Mapping
 from contextlib import suppress
@@ -128,13 +130,17 @@ def write_private_text(path: Path, content: str) -> None:
     if not parent_exists:
         path.parent.chmod(0o700)
 
-    tmp_path = path.with_name(f".{path.name}.tmp")
-    file_descriptor = os.open(tmp_path, os.O_WRONLY | os.O_CREAT | os.O_TRUNC, 0o600)
+    file_descriptor, tmp_name = tempfile.mkstemp(
+        dir=path.parent, prefix=f".{path.name}.", suffix=".tmp", text=True
+    )
+    tmp_path = Path(tmp_name)
     try:
+        os.chmod(tmp_path, 0o600)
         with os.fdopen(file_descriptor, "w", encoding="utf-8") as file:
             file_descriptor = -1
             file.write(content)
-        tmp_path.chmod(0o600)
+            file.flush()
+            os.fsync(file.fileno())
         tmp_path.replace(path)
     except BaseException:
         with suppress(FileNotFoundError):
@@ -279,12 +285,18 @@ def detected_default_auth(
 
 def password_file_permissions_too_open(path: Path) -> bool:
     try:
-        return bool(path.stat().st_mode & 0o077)
+        info = _password_file_lstat(path)
     except FileNotFoundError, OSError:
         return False
+    return stat.S_ISREG(info.st_mode) and bool(info.st_mode & 0o077)
 
 
 def fix_password_file_permissions(path: Path) -> None:
+    info = _password_file_lstat(path)
+    if stat.S_ISLNK(info.st_mode):
+        raise OSError(f"Refusing to chmod symlink password file {path}")
+    if not stat.S_ISREG(info.st_mode):
+        raise OSError(f"Password file is not a regular file: {path}")
     path.chmod(0o600)
 
 
@@ -320,11 +332,18 @@ DEFAULT_PASSWORD_FILE = Path(
 
 def password_file_warning(path: Path) -> str | None:
     try:
-        mode = path.stat().st_mode
+        info = _password_file_lstat(path)
     except FileNotFoundError:
         return None
     except OSError as exc:
         return f"Cannot inspect password file {path}: {exc}"
+    mode = info.st_mode
+    if stat.S_ISLNK(mode):
+        return f"Password file must not be a symlink: {path}."
+    if not stat.S_ISREG(mode):
+        return f"Password file must be a regular file: {path}."
+    if hasattr(os, "getuid") and info.st_uid != os.getuid():
+        return f"Password file must be owned by the current user: {path}."
     if mode & 0o077:
         return (
             f"Password file permissions too open: {path}. "
@@ -333,11 +352,36 @@ def password_file_warning(path: Path) -> str | None:
     return None
 
 
+def _password_file_lstat(path: Path) -> os.stat_result:
+    return path.lstat()
+
+
+def _open_private_password_file(path: Path) -> int:
+    flags = os.O_RDONLY
+    if hasattr(os, "O_NOFOLLOW"):
+        flags |= os.O_NOFOLLOW
+    file_descriptor = os.open(path, flags)
+    try:
+        info = os.fstat(file_descriptor)
+        if not stat.S_ISREG(info.st_mode):
+            raise OSError(f"Password file must be a regular file: {path}")
+        if hasattr(os, "getuid") and info.st_uid != os.getuid():
+            raise OSError(f"Password file must be owned by the current user: {path}")
+        if info.st_mode & 0o077:
+            raise OSError(f"Password file permissions too open: {path}")
+        return file_descriptor
+    except BaseException:
+        os.close(file_descriptor)
+        raise
+
+
 def read_password_file(path: Path = DEFAULT_PASSWORD_FILE) -> str:
     if password_file_warning(path):
         return ""
     try:
-        return path.read_text(encoding="utf-8").splitlines()[0].strip()
+        file_descriptor = _open_private_password_file(path)
+        with os.fdopen(file_descriptor, "r", encoding="utf-8") as file:
+            return file.read().splitlines()[0].strip()
     except FileNotFoundError, IndexError, OSError:
         return ""
 

--- a/src/sambatui/core/settings.py
+++ b/src/sambatui/core/settings.py
@@ -211,7 +211,7 @@ class ConnectionSettings:
                 self.ldap_encryption or DEFAULT_LDAP_ENCRYPTION,
             ),
             (
-                "LDAP compatibility — on relaxes TLS/schema; with password auth prefer UPN user.",
+                "LDAP compatibility — WARNING: on disables TLS certificate verification and allows legacy TLS; use only for trusted DCs.",
                 "ldap_compatibility",
                 "on | off",
                 self.ldap_compatibility or DEFAULT_LDAP_COMPATIBILITY,

--- a/src/sambatui/samba/client.py
+++ b/src/sambatui/samba/client.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
-from collections.abc import Iterable, Sequence
+from collections.abc import Iterable, Mapping, Sequence
+import os
 from dataclasses import dataclass
 from typing import Literal
 
@@ -12,6 +13,7 @@ AUTH_MODES = frozenset({"password", "kerberos"})
 @dataclass(frozen=True)
 class SambaToolConfig:
     server: str
+    executable: str = "samba-tool"
     user: str = ""
     password: str = ""
     auth_mode: str = "password"
@@ -51,7 +53,7 @@ class SambaToolClient:
 
     def dns_command(self, action: str, zone: str, args: Sequence[str]) -> list[str]:
         return [
-            "samba-tool",
+            self.config.executable,
             "dns",
             action,
             self.config.server,
@@ -66,7 +68,7 @@ class SambaToolClient:
 
     def zonelist_command(self) -> list[str]:
         return [
-            "samba-tool",
+            self.config.executable,
             "dns",
             "zonelist",
             self.config.server,
@@ -85,7 +87,7 @@ class SambaToolClient:
         args: list[str] = []
         auth_mode = self.config.normalized_auth_mode
         if auth_mode == "password":
-            args.extend(["-U", f"{self.config.user}%{self.config.password}"])
+            args.extend(["-U", self.config.user])
         elif self.config.user:
             args.extend(["-U", self.config.user])
 
@@ -93,6 +95,11 @@ class SambaToolClient:
         if self.config.krb5_ccache:
             args.append(f"--use-krb5-ccache={self.config.krb5_ccache}")
         return args
+
+    def execution_env(self) -> Mapping[str, str] | None:
+        if self.config.normalized_auth_mode != "password":
+            return None
+        return {**os.environ, "PASSWD": self.config.password}
 
     @staticmethod
     def redact_command(command: Iterable[str]) -> list[str]:

--- a/tests/sambatui/core/test_config.py
+++ b/tests/sambatui/core/test_config.py
@@ -1,3 +1,5 @@
+import os
+import stat
 from pathlib import Path
 from subprocess import CompletedProcess, TimeoutExpired
 
@@ -63,7 +65,61 @@ def test_write_private_text_removes_temp_file_on_failure(
         write_private_text(path, "secret\n")
 
     assert not path.exists()
-    assert not (tmp_path / ".password.tmp").exists()
+    assert not list(tmp_path.glob(".password.*.tmp"))
+
+
+def test_password_file_warning_rejects_symlink_directory_and_wrong_owner(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    target = tmp_path / "target"
+    target.write_text("secret\n", encoding="utf-8")
+    target.chmod(0o600)
+    symlink = tmp_path / "password-link"
+    symlink.symlink_to(target)
+    assert (
+        password_file_warning(symlink)
+        == f"Password file must not be a symlink: {symlink}."
+    )
+    assert password_file_permissions_too_open(symlink) is False
+    with pytest.raises(OSError, match="Refusing to chmod symlink"):
+        fix_password_file_permissions(symlink)
+
+    directory = tmp_path / "password-dir"
+    directory.mkdir()
+    assert password_file_warning(directory) == (
+        f"Password file must be a regular file: {directory}."
+    )
+    with pytest.raises(OSError, match="not a regular file"):
+        fix_password_file_permissions(directory)
+
+    monkeypatch.setattr(config_module.os, "getuid", lambda: -1)
+    assert password_file_warning(target) == (
+        f"Password file must be owned by the current user: {target}."
+    )
+
+
+@pytest.mark.parametrize(
+    ("mode", "uid"),
+    [
+        (stat.S_IFDIR | 0o600, os.getuid()),
+        (stat.S_IFREG | 0o600, -1),
+        (stat.S_IFREG | 0o644, os.getuid()),
+    ],
+)
+def test_read_password_file_rechecks_opened_file_metadata(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch, mode: int, uid: int
+) -> None:
+    path = tmp_path / "password"
+    path.write_text("secret\n", encoding="utf-8")
+    path.chmod(0o600)
+    monkeypatch.setattr(config_module, "password_file_warning", lambda _path: None)
+    monkeypatch.setattr(
+        config_module.os,
+        "fstat",
+        lambda _fd: os.stat_result((mode, 0, 0, 0, uid, 0, 0, 0, 0, 0)),
+    )
+
+    assert read_password_file(path) == ""
 
 
 def test_kerberos_ticket_detection_uses_klist_s() -> None:

--- a/tests/sambatui/core/test_config_edges.py
+++ b/tests/sambatui/core/test_config_edges.py
@@ -58,7 +58,7 @@ def test_config_last_branches(monkeypatch: pytest.MonkeyPatch) -> None:
 
     error_path = Path("/secret/password")
     monkeypatch.setattr(
-        Path, "stat", lambda _path: (_ for _ in ()).throw(OSError("denied"))
+        Path, "lstat", lambda _path: (_ for _ in ()).throw(OSError("denied"))
     )
     assert password_file_warning(error_path) == (
         "Cannot inspect password file /secret/password: denied"

--- a/tests/sambatui/samba/test_samba_client.py
+++ b/tests/sambatui/samba/test_samba_client.py
@@ -33,9 +33,12 @@ def test_password_auth_builds_existing_samba_tool_command() -> None:
         "@",
         "ALL",
         "-U",
-        "EXAMPLE\\administrator%secret",
+        "EXAMPLE\\administrator",
         "--use-kerberos=off",
     ]
+    env = client.execution_env()
+    assert env is not None
+    assert env["PASSWD"] == "secret"
 
 
 def test_kerberos_auth_does_not_require_or_embed_password() -> None:
@@ -50,6 +53,7 @@ def test_kerberos_auth_does_not_require_or_embed_password() -> None:
     )
 
     assert client.authentication_error() is None
+    assert client.execution_env() is None
     assert client.zonelist_command() == [
         "samba-tool",
         "dns",
@@ -77,9 +81,9 @@ def test_configfile_options_and_redaction() -> None:
     assert "--configfile=/etc/samba/smb.conf" in command
     assert "--option=client min protocol=SMB3" in command
     assert "--option=log level=1" in command
-    assert "admin%secret" in command
+    assert "admin%secret" not in command
+    assert client.execution_env() is not None
     assert "admin%secret" not in " ".join(client.redact_command(command))
-    assert "admin%******" in " ".join(client.redact_command(command))
 
 
 def test_authentication_error_prefers_kerberos_for_passwordless_use() -> None:
@@ -136,4 +140,4 @@ def test_dns_command_preserves_generated_command_parts(
 
     assert command[:5] == ["samba-tool", "dns", action, server, zone]
     assert command[5 : 5 + len(args)] == args
-    assert command[-3:] == ["-U", "admin%secret", "--use-kerberos=off"]
+    assert command[-3:] == ["-U", "admin", "--use-kerberos=off"]

--- a/tests/sambatui/test_app_dns_actions.py
+++ b/tests/sambatui/test_app_dns_actions.py
@@ -164,7 +164,8 @@ def test_guided_add_preview_includes_command_and_ptr_suggestion() -> None:
             assert "Record: www A 192.0.2.10" in preview
             assert "2.0.192.in-addr.arpa: 10 PTR www.example.com" in preview
             assert "Command preview: samba-tool dns add dc01.example.com" in preview
-            assert "admin%******" in preview
+            assert "-U admin" in preview
+            assert "secret" not in preview
 
     asyncio.run(run_app())
 


### PR DESCRIPTION
## Summary
- avoid passing Samba passwords in process argv
- harden password file reads/writes against symlink and race issues
- resolve samba-tool path and strengthen LDAP compatibility warnings

## Validation
- mise run check